### PR TITLE
Use environment variables for credential storage

### DIFF
--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -1,7 +1,10 @@
 var AWS = require('aws-sdk'),
     fs = require('fs');
 
-AWS.config.loadFromPath('./aws_config.json');
+AWS.config.update({
+    accessKeyId: process.env.Aws_Access_Key_Id,
+    secretAccessKey: process.env.Aws_Secret_Access_Key
+});
 
 var S3Bucket = function(bucket_name) {
   this.bucket = new AWS.S3({params: {Bucket: bucket_name}});


### PR DESCRIPTION
Please use environmental variables for storing credentials.

.env file should be

Aws_Access_Key_Id="string"
Aws_Secret_Access_Key="string"